### PR TITLE
Enhanced validation of api entry point

### DIFF
--- a/org.review_board.ereviewboard.core/src/org/review_board/ereviewboard/core/client/ReviewboardHttpClient.java
+++ b/org.review_board.ereviewboard.core/src/org/review_board/ereviewboard/core/client/ReviewboardHttpClient.java
@@ -87,10 +87,9 @@ public class ReviewboardHttpClient {
     }
 
     public boolean apiEntryPointExist(IProgressMonitor monitor) throws ReviewboardException {
-
         GetMethod getMethod = new GetMethod(location.getUrl() + "/api/");
-
-        return executeRequest(getMethod, monitor) != HttpStatus.SC_NOT_FOUND;
+        int status = executeRequest(getMethod, monitor);
+        return status == HttpStatus.SC_OK || status == HttpStatus.SC_UNAUTHORIZED;
     }
 
     public String login(String username, String password, IProgressMonitor monitor) throws ReviewboardException {


### PR DESCRIPTION
Verify that api endpoint exists by checking that status != 404 rather than by checking that status == 200.  This way the check works even though we haven't logged in yet.
