### PR TITLE
Fix for ereviewboard issue #101: Empty basedir when projectSvnResource == svnRepository

### DIFF
--- a/org.review_board.ereviewboard.subclipse.ui/src/org/review_board/ereviewboard/subclipse/internal/wizards/PostReviewRequestWizard.java
+++ b/org.review_board.ereviewboard.subclipse.ui/src/org/review_board/ereviewboard/subclipse/internal/wizards/PostReviewRequestWizard.java
@@ -126,6 +126,9 @@ public class PostReviewRequestWizard extends Wizard {
 
                         String basePath = projectSvnResource.getUrl().toString()
                                 .substring(svnRepository.getRepositoryRoot().toString().length());
+                        if ( basePath.length() == 0 ) {
+                            basePath = "/";
+                        }
 
                         Activator.getDefault().trace(TraceLocation.MAIN, "Detected base path " + basePath);
                         


### PR DESCRIPTION
Fix bug in reviewboard svn plugin where if projectSvnResource == svnRepository, a empty basedir
string is passed to the reviewboard server.
