### PR TITLE
fix issue when removing draft review

### DIFF
--- a/org.review_board.ereviewboard.core/src/org/review_board/ereviewboard/core/client/ReviewboardHttpClient.java
+++ b/org.review_board.ereviewboard.core/src/org/review_board/ereviewboard/core/client/ReviewboardHttpClient.java
@@ -267,7 +267,7 @@ public class ReviewboardHttpClient {
 
     public void executeDelete(String url, IProgressMonitor monitor) throws ReviewboardException {
         
-        executeMethod(new DeleteMethod(url), monitor);
+        executeMethod(new DeleteMethod(stripSlash(location.getUrl()) + url), monitor);
     }
 
 


### PR DESCRIPTION
there's an issue when deleting draft review if the reviewboard is not start from root url
