### PR TITLE
Pass peg revision when getting contents for diff

### DIFF
--- a/org.review_board.ereviewboard.subclipse.core/src/org/review_board/ereviewboard/subclipse/core/internal/actions/SubclipseSCMFileContentsLocator.java
+++ b/org.review_board.ereviewboard.subclipse.core/src/org/review_board/ereviewboard/subclipse/core/internal/actions/SubclipseSCMFileContentsLocator.java
@@ -74,7 +74,7 @@ public class SubclipseSCMFileContentsLocator implements SCMFileContentsLocator {
             	resourceUrl = repoLocation.getUrl().appendPath(_filePath);
             }
             SVNRevision revision = SVNRevision.getRevision(_revision);
-            InputStream content = repoLocation.getSVNClient().getContent(resourceUrl, revision);            
+            InputStream content = repoLocation.getSVNClient().getContent(resourceUrl, revision, revision);
             
             return IOUtils.toByteArray(content);
         } catch (ParseException e) {


### PR DESCRIPTION
When trying to display a diff from the review editor for a file that existed at the revision at which the patch was created but does not exist in the HEAD revision, the compare fails with a "filesystem has no item" error.  This can be fixed by explicitly passing the peg revision when getting the contents in SubclipseSCMFileContentsLocator.  This might be the source of the Issue 142 problem.

http://svnbook.red-bean.com/en/1.6/svn.advanced.pegrevs.html

"Note that even when you don't explicitly supply a peg revision or operative revision, they are still present. For your convenience, the default peg revision is BASE for working copy items and HEAD for repository URLs. And when no operative revision is provided, it defaults to being the same revision as the peg revision."