### PR TITLE
Fix the Subclipse requirement to match the plugin

### DIFF
--- a/org.review_board.ereviewboard.subclipse/feature.xml
+++ b/org.review_board.ereviewboard.subclipse/feature.xml
@@ -108,7 +108,7 @@ Inc. in the United States, other countries, or both.
 
    <requires>
       <import feature="org.review_board.ereviewboard" version="0.11.0" match="compatible"/>
-      <import feature="org.tigris.subversion.subclipse" version="1.4.0" match="compatible"/>
+      <import feature="org.tigris.subversion.subclipse" version="1.4.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
Any Subclipse version greater than 1.4.0 should be good.
The feature was requiring a 1.x version so does not work
with the latest Subclipse release (4.2.0) even though the
plugins themselves declare the requirement correctly.